### PR TITLE
feat: add UOS patch

### DIFF
--- a/src/controller/main-controller.js
+++ b/src/controller/main-controller.js
@@ -8,8 +8,29 @@ const {
 const path = require('path');
 const CssInjector = require('../js/css-injector');
 
+// disable UOS patch on default
+const UOS_patch = false
+// https://github.com/BlueSky-07/wechat-token/issues/1
+const UOS_secret = 'Gp8ICJkIEpkICggwMDAwMDAwMRAGGoAIP2dyZlmKevRGDZKoJMMXqdPRe1Iv+vL/2Kj8M/Fx/NMXVTdgTfDVuS5QjUjfXzzkMkxWm0Z1kfL7obGFtXzmgUIKp4RUJn6ehaLuPe4Ne4Gjom4/mifCGjNNtrgO20s4We3jo3FAqhcblYdW4vOTPytXB9HTHScBev1aPT66nS8JfneWgE07oCqB6WrgotoXYFKAJX9iIJbMQFUI8JrnJi3kGqpMjunQSb/npt+TEkgFo7hof7tKhHZHLGm2qyL6d8CweDwprnYWhzey9act6YJydLRlAjXaN35dm/6j8OvEct+H65lwT0hyPN28/Q2GkNcaxvB2NhaM80k3Jck7UHtCq2GLnTEMAV80sKSqTl/EWHNQ1G7APuCRXUvD8JOrmSpRARlUmWEWHeXeeZ0a8Qx+BPkyLxvn1RNtWvnI5hknPSMQ5CUaaBHKSaOwtxuB4fpZXJV2wCah0ACLU+7LFZ5bz1LdEkktzGRyC8GkL8MZwk25dgIiHOVSWgfLBRc4mkG4FMBsmJoCsKxG528Yt8fO0kLGb0pbkWZ2xhjfdveGd3UKwkLypOZ5POpZxbNqlYAQay15Zt0/i4oZnOSWZpCY2H8TtspWpHkVfjR2OpViOgSQGU0gHCQZLQf6hw9w8icKg64zhG82NqUm5/DLIBTq4+Q1MAdSoUmdzNfh+gu8te/ouxTwHF7+83cvXvuWyvONLNdTtOmswIcTwANlFIGCxrv+GKA7FbVapvamJ2c3XCg56xWuUnhaxX9SFFVPeVFLkxHH7pmLvyuWjmTDsVhbPUrHTBN+39tdE1MrpmoQlM+zDcV7G4my39n/8omfCr7UNeqE+nAgTyI31O6QlD/onR4QY5le4lYRWllmprj8O9jNnMWDnufG/2SYzaitCOUa/YL/sI0L0a+HFqNWD8FPApNGBw2bQu0JDyi0Ks4IDf0s9xIVSg4MC70Kpxmb01VnJbihU1IligbnO6roqY0ErBFW8bMCJoOWcaAu35kHVp1y8SMIsp815tkNwvdipWO9qAQch6CbQMFle0REj2FI7cpG0fjlr8jO6FFh8e5P4EpBTq9uHnPy1SrlCL0zdf0DPKddUErATZlEjz+64oDbwqfPYb7ECE2me+Pq+gNH2whFDGkdfsdMHJPP2uHFHZEceIfe7QHkkbMW2h4zTojWJFVPqHCPcUYgsnfY9GuGVoR5MG9cvRt8wa1r0MVXbR/Iz/pKL/qKz4IHNPKvjhegI57VHbAomXk9pAaIPx2M/ZfJC3ZSrskfHwp7P/jybzZbjn9XLDPNp1Vi/ANhT65z67lCtzXG/WW9eXG2RZFwlUdijzDL3uCbBOFWLy28FHJcLHEa37sKVX/nYnpcNiDepZiCBigFMAA='
+
 class MainController {
     constructor() {
+        !UOS_switch || session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+            details.requestHeaders['extspam'] = UOS_secret
+            callback({ requestHeaders: details.requestHeaders })
+        })
+
+        !UOS_switch || session.defaultSession.webRequest.onBeforeRequest({
+            urls: [
+                'https://wx.qq.com/?&lang*',
+                'https://wx2.qq.com/?&lang*'
+            ]
+        },
+            (details, callback) => {
+                callback((details.url.indexOf('&target=t') > -1) ? {} : { redirectURL: 'https://wx.qq.com/?&lang=zh_CN&target=t' })
+            }
+        )
+
         this.init()
     }
 
@@ -22,13 +43,13 @@ class MainController {
             autoHideMenuBar: true,
             resizable: true,
             icon: path.join(__dirname, '../../build/icons/512x512.png'),
-            webPreferences: { 
+            webPreferences: {
                 webSecurity: false,
                 nodeIntegration: true,
             }
         })
 
-        this.window.loadURL('https://wx.qq.com/?lang=zh_CN')
+        this.window.loadURL('https://wx.qq.com/?&lang=zh_CN')
 
         this.window.webContents.on('dom-ready', () => {
             this.window.webContents.insertCSS(CssInjector.login)
@@ -166,7 +187,7 @@ class MainController {
             };
             let titleBar = document.querySelector('.header');
             titleBar.appendChild(toggleButton);
-        `)   
+        `)
     }
 }
 

--- a/src/controller/main-controller.js
+++ b/src/controller/main-controller.js
@@ -9,18 +9,18 @@ const path = require('path');
 const CssInjector = require('../js/css-injector');
 
 // disable UOS patch on default
-const UOS_patch = false
+const UOS_patch = true
 // https://github.com/BlueSky-07/wechat-token/issues/1
 const UOS_secret = 'Gp8ICJkIEpkICggwMDAwMDAwMRAGGoAIP2dyZlmKevRGDZKoJMMXqdPRe1Iv+vL/2Kj8M/Fx/NMXVTdgTfDVuS5QjUjfXzzkMkxWm0Z1kfL7obGFtXzmgUIKp4RUJn6ehaLuPe4Ne4Gjom4/mifCGjNNtrgO20s4We3jo3FAqhcblYdW4vOTPytXB9HTHScBev1aPT66nS8JfneWgE07oCqB6WrgotoXYFKAJX9iIJbMQFUI8JrnJi3kGqpMjunQSb/npt+TEkgFo7hof7tKhHZHLGm2qyL6d8CweDwprnYWhzey9act6YJydLRlAjXaN35dm/6j8OvEct+H65lwT0hyPN28/Q2GkNcaxvB2NhaM80k3Jck7UHtCq2GLnTEMAV80sKSqTl/EWHNQ1G7APuCRXUvD8JOrmSpRARlUmWEWHeXeeZ0a8Qx+BPkyLxvn1RNtWvnI5hknPSMQ5CUaaBHKSaOwtxuB4fpZXJV2wCah0ACLU+7LFZ5bz1LdEkktzGRyC8GkL8MZwk25dgIiHOVSWgfLBRc4mkG4FMBsmJoCsKxG528Yt8fO0kLGb0pbkWZ2xhjfdveGd3UKwkLypOZ5POpZxbNqlYAQay15Zt0/i4oZnOSWZpCY2H8TtspWpHkVfjR2OpViOgSQGU0gHCQZLQf6hw9w8icKg64zhG82NqUm5/DLIBTq4+Q1MAdSoUmdzNfh+gu8te/ouxTwHF7+83cvXvuWyvONLNdTtOmswIcTwANlFIGCxrv+GKA7FbVapvamJ2c3XCg56xWuUnhaxX9SFFVPeVFLkxHH7pmLvyuWjmTDsVhbPUrHTBN+39tdE1MrpmoQlM+zDcV7G4my39n/8omfCr7UNeqE+nAgTyI31O6QlD/onR4QY5le4lYRWllmprj8O9jNnMWDnufG/2SYzaitCOUa/YL/sI0L0a+HFqNWD8FPApNGBw2bQu0JDyi0Ks4IDf0s9xIVSg4MC70Kpxmb01VnJbihU1IligbnO6roqY0ErBFW8bMCJoOWcaAu35kHVp1y8SMIsp815tkNwvdipWO9qAQch6CbQMFle0REj2FI7cpG0fjlr8jO6FFh8e5P4EpBTq9uHnPy1SrlCL0zdf0DPKddUErATZlEjz+64oDbwqfPYb7ECE2me+Pq+gNH2whFDGkdfsdMHJPP2uHFHZEceIfe7QHkkbMW2h4zTojWJFVPqHCPcUYgsnfY9GuGVoR5MG9cvRt8wa1r0MVXbR/Iz/pKL/qKz4IHNPKvjhegI57VHbAomXk9pAaIPx2M/ZfJC3ZSrskfHwp7P/jybzZbjn9XLDPNp1Vi/ANhT65z67lCtzXG/WW9eXG2RZFwlUdijzDL3uCbBOFWLy28FHJcLHEa37sKVX/nYnpcNiDepZiCBigFMAA='
 
 class MainController {
     constructor() {
-        !UOS_switch || session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        !UOS_patch || session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
             details.requestHeaders['extspam'] = UOS_secret
             callback({ requestHeaders: details.requestHeaders })
         })
 
-        !UOS_switch || session.defaultSession.webRequest.onBeforeRequest({
+        !UOS_patch || session.defaultSession.webRequest.onBeforeRequest({
             urls: [
                 'https://wx.qq.com/?&lang*',
                 'https://wx2.qq.com/?&lang*'


### PR DESCRIPTION
Fixes #63 

feat:
Add UOS patch so that all users can login to web wechat (on their own risks).
However the [default](https://github.com/MichaelMai2000/freechat/blob/6c7653219a83bedb07688879dc8a18bb24a979e8/src/controller/main-controller.js#L12) setting enables UOS patch.

references:
https://github.com/BlueSky-07/wechat-token/issues/1